### PR TITLE
Add test harness for StateMachine and CooldownGuard

### DIFF
--- a/src/cooldown_guard.lua
+++ b/src/cooldown_guard.lua
@@ -1,0 +1,26 @@
+local CooldownGuard = {}
+CooldownGuard.__index = CooldownGuard
+
+---Create a new cooldown guard.
+---@param duration number cooldown duration in seconds
+---@param time_fn function? optional time provider
+function CooldownGuard:new(duration, time_fn)
+    return setmetatable({
+        duration = duration,
+        time_fn = time_fn or os.clock,
+        last_time = -math.huge
+    }, self)
+end
+
+---Check if the guard is ready.
+---@return boolean
+function CooldownGuard:is_ready()
+    return (self.time_fn() - self.last_time) >= self.duration
+end
+
+---Mark the cooldown as used.
+function CooldownGuard:use()
+    self.last_time = self.time_fn()
+end
+
+return CooldownGuard

--- a/src/state_machine.lua
+++ b/src/state_machine.lua
@@ -1,0 +1,43 @@
+local StateMachine = {}
+StateMachine.__index = StateMachine
+
+---Create a new state machine.
+---@param guard table cooldown guard instance
+function StateMachine:new(guard)
+    return setmetatable({
+        state = "idle",
+        guard = guard
+    }, self)
+end
+
+---Get current state.
+function StateMachine:get_state()
+    return self.state
+end
+
+---Attempt to cast a spell, transitioning state when successful.
+---@param spell_id number
+---@return boolean
+function StateMachine:try_cast(spell_id)
+    -- Check for player context; stubbed in tests
+    get_local_player()
+    if not self.guard:is_ready() then
+        return false
+    end
+
+    if cast_spell.self(spell_id, 0.0) then
+        self.guard:use()
+        self.state = "casting"
+        return true
+    end
+    return false
+end
+
+---Update the state machine based on cooldown.
+function StateMachine:update()
+    if self.state == "casting" and self.guard:is_ready() then
+        self.state = "idle"
+    end
+end
+
+return StateMachine

--- a/tests/state_machine_spec.lua
+++ b/tests/state_machine_spec.lua
@@ -1,0 +1,48 @@
+local CooldownGuard = require("src.cooldown_guard")
+local StateMachine = require("src.state_machine")
+
+describe("StateMachine", function()
+    it("transitions with cooldown", function()
+        local t = 0
+        local function time_fn() return t end
+        local guard = CooldownGuard:new(1, time_fn)
+        local machine = StateMachine:new(guard)
+
+        local player_called = false
+        get_local_player = function()
+            player_called = true
+            return {}
+        end
+
+        local cast_called = false
+        cast_spell = {
+            self = function(spell_id, anim_time)
+                cast_called = true
+                return true
+            end
+        }
+
+        assert.equals("idle", machine:get_state())
+        assert.is_true(machine:try_cast(123))
+        assert.is_true(player_called)
+        assert.is_true(cast_called)
+        assert.equals("casting", machine:get_state())
+
+        t = 1.1
+        machine:update()
+        assert.equals("idle", machine:get_state())
+    end)
+end)
+
+describe("CooldownGuard", function()
+    it("enforces timing", function()
+        local t = 0
+        local function time_fn() return t end
+        local guard = CooldownGuard:new(2, time_fn)
+        assert.is_true(guard:is_ready())
+        guard:use()
+        assert.is_false(guard:is_ready())
+        t = 2.1
+        assert.is_true(guard:is_ready())
+    end)
+end)


### PR DESCRIPTION
## Summary
- add simple StateMachine and CooldownGuard modules
- test state transitions and cooldown timing with stubbed API

## Testing
- `busted tests/state_machine_spec.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f37f47e0c8332b804aba64b647239