### PR TITLE
feat: add cooldown guard and services

### DIFF
--- a/core/CombatService.lua
+++ b/core/CombatService.lua
@@ -1,0 +1,23 @@
+local cast_spell = require("cast_spell")
+local CooldownGuard = require("core/CooldownGuard")
+
+local CombatService = {}
+
+-- Attempts to cast a spell on a target using the CooldownGuard.
+-- @param target game.object
+-- @param spell_id number
+-- @param animation_time number
+-- @param cooldown number|nil optional cooldown duration for the spell
+-- @return boolean
+function CombatService.cast(target, spell_id, animation_time, cooldown)
+    if not CooldownGuard:can_cast(spell_id, cooldown) then
+        return false
+    end
+    -- Lock movement for duration of animation to avoid interruptions
+    if animation_time then
+        CooldownGuard:lock_movement(animation_time)
+    end
+    return cast_spell.target(target, spell_id, animation_time)
+end
+
+return CombatService

--- a/core/CooldownGuard.lua
+++ b/core/CooldownGuard.lua
@@ -1,0 +1,32 @@
+local CooldownGuard = {
+    spell_timers = {},
+    locked_until = 0
+}
+
+-- Checks whether a spell can be cast and updates timers when allowed.
+-- @param spell_id number
+-- @param cooldown number|nil optional cooldown to apply if cast succeeds
+-- @return boolean
+function CooldownGuard:can_cast(spell_id, cooldown)
+    local now = get_time_since_inject()
+    local ready_time = self.spell_timers[spell_id] or 0
+    if now < ready_time or now < self.locked_until then
+        return false
+    end
+    if cooldown then
+        self.spell_timers[spell_id] = now + cooldown
+    end
+    return true
+end
+
+-- Locks movement for the given duration in seconds.
+-- @param duration number
+function CooldownGuard:lock_movement(duration)
+    local now = get_time_since_inject()
+    local lock_until = now + (duration or 0)
+    if lock_until > self.locked_until then
+        self.locked_until = lock_until
+    end
+end
+
+return CooldownGuard

--- a/core/MovementService.lua
+++ b/core/MovementService.lua
@@ -1,0 +1,17 @@
+local pathfinder = require("pathfinder")
+local CooldownGuard = require("core/CooldownGuard")
+
+local MovementService = {}
+
+-- Moves to a position if movement is not locked.
+-- @param position vec3
+-- @return boolean
+function MovementService.move_to(position)
+    local now = get_time_since_inject()
+    if now < CooldownGuard.locked_until then
+        return false
+    end
+    return pathfinder.request_move(position)
+end
+
+return MovementService


### PR DESCRIPTION
## Summary
- add `CooldownGuard` to track spell cooldowns and movement locks
- gate casts and movement through `CombatService` and `MovementService`

## Testing
- `lua -e "assert(loadfile('core/CooldownGuard.lua'))" && lua -e "assert(loadfile('core/CombatService.lua'))" && lua -e "assert(loadfile('core/MovementService.lua'))" *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689f37ef7b14833292d25b676698f93b