### PR TITLE
feat: centralize pathfinding

### DIFF
--- a/Sorc_Rota_EN-82/main.lua
+++ b/Sorc_Rota_EN-82/main.lua
@@ -541,10 +541,10 @@ on_update(function ()
                 -- if is_blood_mist then
                 --     local closer_target_position = closer_target:get_position();
                 --     local move_pos = closer_target_position:get_extended(player_position, -5.0);
-                --     if pathfinder.move_to_cpathfinder(move_pos) then
+                --     if my_utility.move_to(move_pos) then
                 --         cast_end_time = current_time + 0.40;
                 --         can_move = move_timer + 1.5;
-                --         --console.print("自动游戏 move_to_cpathfinder - 111")
+                --         --console.print("自动游戏 move_to - 111")
                 --     end
                 -- else
                     local closer_target_position = closer_target:get_position();
@@ -553,9 +553,9 @@ on_update(function ()
                     -- 使用移动技能到目标位置（参考piteer1逻辑）
                     use_movement_spells_to_target(move_pos);
                     
-                    if pathfinder.move_to_cpathfinder(move_pos) then
+                    if my_utility.move_to(move_pos) then
                         can_move = move_timer + 1.5;
-                        --console.print("自动游戏 move_to_cpathfinder - 222")
+                        --console.print("自动游戏 move_to - 222")
                     end
                 -- end
                 

--- a/Sorc_Rota_EN-82/my_utility/my_utility.lua
+++ b/Sorc_Rota_EN-82/my_utility/my_utility.lua
@@ -1,3 +1,5 @@
+local PathingService = require("services/PathingService")
+
 local function is_auto_play_enabled()
     -- auto play fire spells without orbwalker
     local is_auto_play_active = auto_play.is_active();
@@ -48,6 +50,10 @@ local horde_objectives = {
     "BSK_cannibal_brute_boss",
     "BSK_skeleton_boss"
 }
+
+local function move_to(pos)
+    return PathingService:move_to(pos)
+end
 
 local function is_action_allowed()
 
@@ -478,6 +484,7 @@ return
     is_action_allowed = is_action_allowed,
 
     is_auto_play_enabled = is_auto_play_enabled,
+    move_to = move_to,
 
     -- decrepify & bone_prision
     get_best_point = get_best_point,

--- a/Sorc_Rota_EN-82/services/PathingService.lua
+++ b/Sorc_Rota_EN-82/services/PathingService.lua
@@ -1,0 +1,38 @@
+local PathingService = {}
+
+--- Moves the player using the internal pathfinder.
+-- @param pos vec3 Destination position
+-- @return boolean success
+function PathingService:move_to(pos)
+    if not pos then
+        return false
+    end
+    return pathfinder.move_to_cpathfinder(pos)
+end
+
+--- Forces a movement command to the given position.
+-- @param pos vec3
+-- @return boolean
+function PathingService:force_move(pos)
+    if not pos then
+        return false
+    end
+    return pathfinder.force_move(pos)
+end
+
+--- Issues a non-blocking move request.
+-- @param pos vec3
+function PathingService:request_move(pos)
+    if not pos then
+        return
+    end
+    pathfinder.request_move(pos)
+end
+
+--- Clears any cached pathing information.
+function PathingService:clear_path()
+    pathfinder.clear_stored_path()
+end
+
+return PathingService
+


### PR DESCRIPTION
## Summary
- add PathingService wrapping custom pathfinder
- expose `move_to` helper through my_utility
- route auto-play movement to PathingService

## Testing
- `luacheck .` *(fails: command not found)*
- `luac -p 'Sorc_Rota_EN-82/services/PathingService.lua'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f37edeca083329845fb63c126b3d2