### PR TITLE
Reuse target selector tables

### DIFF
--- a/Sorc_Rota_EN-82/main.lua
+++ b/Sorc_Rota_EN-82/main.lua
@@ -200,6 +200,11 @@ local mount_buff_name_hash_c = 1923;
 local my_utility = require("my_utility/my_utility");
 local my_target_selector = require("my_utility/my_target_selector");
 
+-- Reusable tables to avoid per-frame allocations
+local collision_table = { true, 1.0 }
+local floor_table = { true, 5.0 }
+local angle_table = { false, 90.0 }
+
 on_update(function ()
 
     local local_player = get_local_player();
@@ -234,15 +239,11 @@ on_update(function ()
     local screen_range = 12.0;
     local player_position = get_player_position();
 
-    local collision_table = { true, 1.0 };
-    local floor_table = { true, 5.0 };
-    local angle_table = { false, 90.0 };
-
     local entity_list = my_target_selector.get_target_list(
         player_position,
-        screen_range, 
-        collision_table, 
-        floor_table, 
+        screen_range,
+        collision_table,
+        floor_table,
         angle_table);
 
     -- 获取any_weight值用于过滤普通目标
@@ -636,15 +637,11 @@ on_render(function ()
     local screen_range = 12.0;
     local player_position = get_player_position();
 
-    local collision_table = { true, 1.0 };
-    local floor_table = { true, 5.0 };
-    local angle_table = { false, 90.0 };
-
     local entity_list = my_target_selector.get_target_list(
         player_position,
-        screen_range, 
-        collision_table, 
-        floor_table, 
+        screen_range,
+        collision_table,
+        floor_table,
         angle_table);
 
     -- 获取any_weight值用于过滤普通目标


### PR DESCRIPTION
## Summary
- Define collision, floor, and angle lookup tables once and reuse them to avoid per-frame allocation

## Testing
- `luac -p Sorc_Rota_EN-82/main.lua` *(fails: command not found)*
- `lua -e 'assert(loadfile("Sorc_Rota_EN-82/main.lua"))'` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689f37ecffe483328cdcac796d9f7064