### PR TITLE
Fix angle check to use angle table

### DIFF
--- a/Sorc_Rota_EN-82/my_utility/my_target_selector.lua
+++ b/Sorc_Rota_EN-82/my_utility/my_target_selector.lua
@@ -324,8 +324,8 @@ local function get_target_list(source, range, collision_table, floor_table, angl
         if angle_table.is_enabled then
             local cursor_position = cursor_pos();
             local angle = unit_position.angle(cursor_position, source);
-            local is_outside_angle = angle > floor_table.max_angle
-        
+            local is_outside_angle = angle > angle_table.max_angle
+
             if is_outside_angle then
                 goto continue
             end


### PR DESCRIPTION
## Summary
- Correct target selector angle filtering to reference angle_table instead of floor_table

## Testing
- `luac -p Sorc_Rota_EN-82/my_utility/my_target_selector.lua` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f37ea06508332a32553961ca76642